### PR TITLE
Fixed closed statement running on non-open connection

### DIFF
--- a/JDBC.NET.Data/JdbcCommand.cs
+++ b/JDBC.NET.Data/JdbcCommand.cs
@@ -291,7 +291,12 @@ namespace JDBC.NET.Data
             if (_isDisposed)
                 return;
 
-            CloseStatement();
+            var dbConnection = this.Connection;
+            if (dbConnection is not null)
+            {
+                if (dbConnection.State is ConnectionState.Open or ConnectionState.Executing or ConnectionState.Fetching)
+                    CloseStatement();
+            }
             _isDisposed = true;
 
             base.Dispose(disposing);

--- a/JDBC.NET.Data/JdbcCommand.cs
+++ b/JDBC.NET.Data/JdbcCommand.cs
@@ -276,7 +276,7 @@ namespace JDBC.NET.Data
             if (Connection is not JdbcConnection jdbcConnection)
                 throw new InvalidOperationException();
 
-            if (Connection.State is ConnectionState.Open or ConnectionState.Executing or ConnectionState.Fetching)
+            if (Connection.State != ConnectionState.Closed)
             {
                 jdbcConnection.Bridge.Statement.closeStatement(new CloseStatementRequest
                 {

--- a/JDBC.NET.Data/JdbcCommand.cs
+++ b/JDBC.NET.Data/JdbcCommand.cs
@@ -276,10 +276,13 @@ namespace JDBC.NET.Data
             if (Connection is not JdbcConnection jdbcConnection)
                 throw new InvalidOperationException();
 
-            jdbcConnection.Bridge.Statement.closeStatement(new CloseStatementRequest
+            if (Connection.State is ConnectionState.Open or ConnectionState.Executing or ConnectionState.Fetching)
             {
-                StatementId = StatementId
-            });
+                jdbcConnection.Bridge.Statement.closeStatement(new CloseStatementRequest
+                {
+                    StatementId = StatementId
+                });
+            }
 
             StatementId = null;
         }
@@ -290,13 +293,8 @@ namespace JDBC.NET.Data
         {
             if (_isDisposed)
                 return;
-
-            var dbConnection = this.Connection;
-            if (dbConnection is not null)
-            {
-                if (dbConnection.State is ConnectionState.Open or ConnectionState.Executing or ConnectionState.Fetching)
-                    CloseStatement();
-            }
+            
+            CloseStatement();
             _isDisposed = true;
 
             base.Dispose(disposing);


### PR DESCRIPTION
When disposing of a command, sometimes the connection has already been closed or is not working. This causes a `JDBCException`. This fix checks if the connection is able to receive the command. If the connection is already closed, there's no point in trying to do `closeStatement`. So instead, if the connection is already closed, it just doesn't send the `CloseStatementRequest`.