### PR TITLE
QD-1367 Fix LibraryJarFiles Value cannot be null error

### DIFF
--- a/JDBC.NET.Data/JdbcConnectionStringBuilder.cs
+++ b/JDBC.NET.Data/JdbcConnectionStringBuilder.cs
@@ -41,8 +41,25 @@ namespace JDBC.NET.Data
 
         public string[] LibraryJarFiles
         {
-            get => JsonSerializer.Deserialize<string[]>(GetValue<string>(nameof(LibraryJarFiles)));
-            set => SetValue(nameof(LibraryJarFiles), JsonSerializer.Serialize(value));
+            get
+            {
+                var value = GetValue<string>(nameof(LibraryJarFiles));
+
+                if (string.IsNullOrEmpty(value))
+                    return Array.Empty<string>();
+
+                return JsonSerializer.Deserialize<string[]>(value);
+            }
+            set
+            {
+                if (value is null)
+                {
+                    SetValue(nameof(LibraryJarFiles), (string)null);
+                    return;
+                }
+
+                SetValue(nameof(LibraryJarFiles), JsonSerializer.Serialize(value));
+            }
         }
         #endregion
 


### PR DESCRIPTION
## Summary
LibraryJarFiles 옵션으로 인해 Value cannot be null 오류가 발생하는 문제를 해결합니다.

## Issue 
QD-1367 