### PR TITLE
Support ASP.Net Core

### DIFF
--- a/JDBC.NET.Data/Models/JdbcBridge.cs
+++ b/JDBC.NET.Data/Models/JdbcBridge.cs
@@ -137,7 +137,7 @@ namespace JDBC.NET.Data.Models
             if (!File.Exists(resolvedOptionsDriverPath))
             {
                 //maybe Options.DriverPath is a relative driver path
-                resolvedOptionsDriverPath = Path.Combine(exeLoc, Options.DriverPath);
+                resolvedOptionsDriverPath = Path.Join(exeLoc, Options.DriverPath);
 
                 if (!File.Exists(resolvedOptionsDriverPath))
                     throw new FileNotFoundException($"'{Options.DriverPath}' and '{resolvedOptionsDriverPath}' not found!");

--- a/JDBC.NET.Data/Models/JdbcBridge.cs
+++ b/JDBC.NET.Data/Models/JdbcBridge.cs
@@ -124,9 +124,29 @@ namespace JDBC.NET.Data.Models
 
         private IEnumerable<string> ResolveJarFiles()
         {
-            var defaultJarFiles = new[] { jarPath, Options.DriverPath };
+            var exeLoc = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            var mainJarLocation = Path.Join(exeLoc, jarPath);
+
+            if (!File.Exists(mainJarLocation))
+                throw new FileNotFoundException(@$"'{jarPath}' not found at '{mainJarLocation}'");
+
+            var resolvedOptionsDriverPath = Options.DriverPath;
+
+            //check if Options.DriverPath is the actual full path to the file
+            if (!File.Exists(resolvedOptionsDriverPath))
+            {
+                //maybe Options.DriverPath is a relative driver path
+                resolvedOptionsDriverPath = Path.Combine(exeLoc, Options.DriverPath);
+
+                if (!File.Exists(resolvedOptionsDriverPath))
+                    throw new FileNotFoundException($"'{Options.DriverPath}' and '{resolvedOptionsDriverPath}' not found!");
+            }
+
+            var defaultJarFiles = new[] { mainJarLocation, resolvedOptionsDriverPath };
 
             IEnumerable<string> libraryJarFiles = Options.LibraryJarFiles ?? Enumerable.Empty<string>();
+
             return defaultJarFiles.Concat(libraryJarFiles);
         }
         #endregion


### PR DESCRIPTION
Currently `jarPath` is passed into `javaRunArgs` via `ResolveJarFiles`. `jarPath` is a relative path, and cannot be resolved on asp.net core. In this change `ResolveJarFiles` has been updated to use the full path for the required jar file (`"JDBC.NET.Bridge.jar"`), relative to the execution directory. Then resolves the options-specified jar file (`Options.DriverPath`) as is, or resolves it as a full path relative to the execution directory.