### PR TITLE
QP-6953 Add JdbcEventSource to received standard output and error

### DIFF
--- a/JDBC.NET.Data/JDBC.NET.Data.csproj
+++ b/JDBC.NET.Data/JDBC.NET.Data.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="J2NET" Version="1.3.1" />
+    <PackageReference Include="J2NET" Version="1.3.2" />
     <PackageReference Include="Google.Protobuf" Version="3.22.3" />
     <PackageReference Include="Grpc" Version="2.46.6" />
     <PackageReference Include="Grpc.Tools" Version="2.54.0">

--- a/JDBC.NET.Data/JdbcEventSource.cs
+++ b/JDBC.NET.Data/JdbcEventSource.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.Tracing;
+
+namespace JDBC.NET.Data;
+
+[EventSource(Name = Name)]
+public class JdbcEventSource : EventSource
+{ 
+    public new const string Name = "JDBC.NET.Data.JdbcEventSource";
+    
+    public static JdbcEventSource Log = new();
+
+    private JdbcEventSource()
+    {
+    }
+
+    [Event(1, Level = EventLevel.Verbose)]
+    public void StandardOutputDataReceived(string data)
+    {
+        WriteEvent(1, data);
+    }
+
+    [Event(2, Level = EventLevel.Verbose)]
+    public void StandardErrorDataReceived(string data)
+    {
+        WriteEvent(2, data);
+    }
+}

--- a/JDBC.NET.Sample/JdbcEventListener.cs
+++ b/JDBC.NET.Sample/JdbcEventListener.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using JDBC.NET.Data;
+
+namespace JDBC.NET.Sample;
+
+public class JdbcEventListener : EventListener
+{
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        base.OnEventSourceCreated(eventSource);
+
+        if (eventSource.Name != JdbcEventSource.Name)
+            return;
+
+        EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All);
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        base.OnEventWritten(eventData);
+
+        if (eventData.EventSource.Name != JdbcEventSource.Name)
+            return;
+
+        switch (eventData.EventId)
+        {
+            case 1:
+                Console.WriteLine($"[JDBC.NET] {eventData.Payload?.First()}");
+                return;
+
+            case 2:
+                Console.Error.WriteLine($"[JDBC.NET] {eventData.Payload?.First()}");
+                return;
+        }
+    }
+}

--- a/JDBC.NET.Sample/Program.cs
+++ b/JDBC.NET.Sample/Program.cs
@@ -43,6 +43,8 @@ namespace JDBC.NET.Sample
 
         private static void Main(string[] args)
         {
+            using var jdbcEventListener = new JdbcEventListener();
+
             Console.Write("Driver Path : ");
             var driverPath = Console.ReadLine();
 


### PR DESCRIPTION
## Summary
Log 개선의 일환으로 JDBC.NET의 Standard output, error를 받아서 출력할 수 있는 구조로 변경합니다.

## Changes
 - J2NET을 버전 업데이트하고 Process에 옵션을 추가하여 실행합니다.
 - JdbcEventSource를 추가하여, 외부에서 EventListener를 통해 데이터를 받을 수 있도록 개선합니다.
 - Sample에 JdbcEventSource의 이벤트를 받아 출력하는 JdbcEventListener를 구현합니다.